### PR TITLE
Fixed Priest Set vendor & Titanite Shard type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1259,7 +1259,7 @@
                     <li data-id="playthrough_16_3">Get the <a href="http://darksouls2.wikidot.com/titanite-shard">Titanite Shard</a> from the well, break the wooden bit above it, go up the ramp and jump in to the well to get the <a href="http://darksouls2.wikidot.com/witching-urn">Witching Urns</a></li>
                     <li data-id="playthrough_16_4">Go along the tunnel, up the ladder, get the <a href="http://darksouls2.wikidot.com/human-effigy">Human Effigies</a> from the chest, and leave the building</li>
                     <li data-id="playthrough_16_5">Go down the hill, watching out for the boulder traps, get the <a href="http://darksouls2.wikidot.com/soul-of-a-nameless-soldier">Soul of a Nameless Soldier</a>, go up the ladder and get the <a href="http://darksouls2.wikidot.com/soul-of-a-brave-warrior">Soul Of A Brave Warrior</a></li>
-                    <li data-id="playthrough_16_6">Continue down the hill, get the <a href="http://darksouls2.wikidot.com/titanite-shard">Titanite Shard</a> from the corpse on the ledge and open the door</li>
+                    <li data-id="playthrough_16_6">Continue down the hill, get the <a href="http://darksouls2.wikidot.com/large-titanite-shard">Large Titanite Shard</a> from the corpse on the ledge and open the door</li>
                     <li data-id="playthrough_16_7">Follow the tunnel, clear out the spiders at the bottom, get the <a href="http://darksouls2.wikidot.com/heavy-bolt">Heavy Bolts</a> from the chest, and open the door to find a fog gate</li>
                     <li data-id="playthrough_16_70">Before going through the fog gate open the illusory wall in front of you and go up the stairs to get the <a href="http://darksouls2.wikidot.com/estus-flask-shard">Estus Flask Shard</a></li>
                     <li data-id="playthrough_16_8">Go through the fog gate and kill the <a href="http://darksouls2.wikidot.com/prowling-magus-congregation">Prowling Magus & Congregation</a> boss
@@ -1276,9 +1276,9 @@
                     <li data-id="playthrough_16_11">Talk to <a href="http://darksouls2.wikidot.com/cromwell-the-pardoner">Cromwell The Pardoner</a> to have your sins pardoned and buy anything you need from him
                         <ul>
                             <li data-id="playthrough_16_11_1"><a href="http://darksouls2.wikidot.com/white-priest-headpiece">White Priest Headpiece</a> @ 4,500 souls</li>
-                            <li data-id="playthrough_16_11_2"><a href="http://darksouls2.wikidot.com/white-priest-robe">White Priest Headpiece</a> @ 5,000 souls</li>
-                            <li data-id="playthrough_16_11_3"><a href="http://darksouls2.wikidot.com/white-priest-gloves">White Priest Robe</a> @ 4,600 souls</li>
-                            <li data-id="playthrough_16_11_4"><a href="http://darksouls2.wikidot.com/white-priest-skirt">White Priest Gloves</a> @ 4,800 souls</li>
+                            <li data-id="playthrough_16_11_2"><a href="http://darksouls2.wikidot.com/white-priest-robe">White Priest Robe</a> @ 5,000 souls</li>
+                            <li data-id="playthrough_16_11_3"><a href="http://darksouls2.wikidot.com/white-priest-gloves">White Priest Gloves</a> @ 4,600 souls</li>
+                            <li data-id="playthrough_16_11_4"><a href="http://darksouls2.wikidot.com/white-priest-skirt">White Priest Skirt</a> @ 4,800 souls</li>
                             <li data-id="playthrough_16_11_5"><a href="http://darksouls2.wikidot.com/poisonbite-ring">Poisonbite Ring</a> @ 5,500 souls</li>
                             <li data-id="playthrough_16_11_6"><a href="http://darksouls2.wikidot.com/bloodbite-ring">Bloodbite Ring</a> @ 7,000 souls</li>
                             <li data-id="playthrough_16_11_7"><a href="http://darksouls2.wikidot.com/cursebite-ring">Cursebite Ring</a> @ 9,000 souls</li>


### PR DESCRIPTION
Corrected Priest Set titles & Titanite Shard type for Brightstone Cove Tseldora
