### PR TITLE
Fixes for Shrine of Amana & Drangleic Castle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1472,7 +1472,7 @@
                         </ul>
                     </li>
                     <li data-id="playthrough_19_15">Fall down the collapsing floor in the third room on the left and pick up the <a href="http://darksouls2.wikidot.com/faraam-set">Faram Set</a></li>
-                    <li data-id="playthrough_19_16">Light the bonfire in the cave on the right and go talk to X in the cave on the left</li>
+                    <li data-id="playthrough_19_16">Light the bonfire in the cave on the right and go talk to <a href="http://darksouls2.wikidot.com/darkdiver-grandahl">Darkdiver Grandahl</a> in the cave on the left</li>
                     <li data-id="playthrough_19_17">This is the third of three locations where you need to talk to him to be able to join the <a href="http://darksouls2.wikidot.com/pilgrims-of-dark">Pilgrims Of Dark</a> covenant</li>
                     <li data-id="playthrough_19_18">If you join his covenant you can talk to him and buy anything you need from him
                         <ul>
@@ -1567,10 +1567,10 @@
                 <a name="Shrine_Of_Amana"></a>
                 <h3><a href="http://darksouls2.wikidot.com/shrine-of-amana">Shrine of Amana</a> (Levels 95-105) <span id="playthrough_totals_20"></span></h3>
                 <ul>
-                    <li data-id="playthrough_20_1">Go down the steps, open the door and go along the ledge and hit the branch to knock down the X</li>
+                    <li data-id="playthrough_20_1">Go down the steps, open the door and go along the ledge and hit the branch to knock down the <a href="http://darksouls2.wikidot.com/flame-butterfly">Flame Butterfly</a> and <a href="http://darksouls2.wikidot.com/twinkling-titanite">Twinkling Titanite</a> to the area below</li>
                     <li data-id="playthrough_20_2">Go to the end of the ledge and get the <a href="http://darksouls2.wikidot.com/wilted-dusk-herb">Wilted Dusk Herb</a> and <a href="http://darksouls2.wikidot.com/skeptic-s-spice">Skeptic's Spice</a> from the chest</li>
                     <li data-id="playthrough_20_3">Go back to the building, go down and get the <a href="http://darksouls2.wikidot.com/large-soul-of-a-nameless-soldier">Large Soul Of A Nameless Soldier</a> from under the stairs at the bottom</li>
-                    <li data-id="playthrough_20_4">From this point watch out for ranged attacks from <a href="http://darksouls2.wikidot.com/priestess-of-amana">Priestesses Of Amana</a>, <a href="http://darksouls2.wikidot.com/corrupted-lurker">Corrupted Lurkers</a> hidden in the water and underwater cliffs</li>
+                    <li data-id="playthrough_20_4">From this point watch out for ranged attacks from <a href="http://darksouls2.wikidot.com/amana-shrine-maiden">Amana Shrine Maiden</a>, <a href="http://darksouls2.wikidot.com/corrupted-lurker">Corrupted Lurkers</a> hidden in the water and underwater cliffs</li>
                     <li data-id="playthrough_20_5">Head outside, go around to the right and get the <a href="http://darksouls2.wikidot.com/flame-butterfly">Flame Butterfly</a> and <a href="http://darksouls2.wikidot.com/twinkling-titanite">Twinkling Titanite</a> that you knocked down</li>
                     <li data-id="playthrough_20_6">Move forwards towards the hut and talk to the first <a href="http://darksouls2.wikidot.com/milfanito">Milfanito</a> to exhaust her dialog and get a <a href="http://darksouls2.wikidot.com/smooth-silky-stone">Smooth and Silky Stone</a></li>
                     <li data-id="playthrough_20_7">Go outside and around the side of the house, watching out for the curse pot, and get the <a href="http://darksouls2.wikidot.com/crimson-water">Crimson Waters</a> from the chest</li>
@@ -1586,7 +1586,9 @@
                     <li data-id="playthrough_20_17">Go back and in to the building to get a <a href="http://darksouls2.wikidot.com/large-soul-of-a-proud-knight">Large Soul Of A Proud Knight</a> and <a href="http://darksouls2.wikidot.com/old-radiant-lifegem">Old Radiant Lifegem</a></li>
                     <li data-id="playthrough_20_18">Go out the back door of the hut and watch for the ambush to the right</li>
                     <li data-id="playthrough_20_19">Out the back door and slightly to the right is a submerged chest with the <a href="http://darksouls2.wikidot.com/fire-tempest">Fire Tempest</a> Pyromancy</li>
-                    <li data-id="playthrough_20_20">It's tough to find but aim roughly for where two roots come down from the roof in to the water but be careful not to fall off the underwater cliff</li>
+                    <ul>
+                        <li data-id="playthrough_20_20">It's tough to find but aim roughly for where two roots come down from the roof in to the water but be careful not to fall off the underwater cliff</li>
+                    </ul>
                     <li data-id="playthrough_20_21">Continue passed the hut, break the branches to the cave on the left, kill the <a href="http://darksouls2.wikidot.com/ogre">Ogre</a> and get the <a href="http://darksouls2.wikidot.com/singer-s-dress">Singer's Dress</a> and <a href="http://darksouls2.wikidot.com/life-ring">Life Ring +2</a></li>
                     <li data-id="playthrough_20_22">Get the <a href="http://darksouls2.wikidot.com/alluring-skull">Alluring Skulls</a> from the ramp to the left of the fog gate, and the <a href="http://darksouls2.wikidot.com/soul-of-a-hero">Soul Of A Hero</a> and <a href="http://darksouls2.wikidot.com/divine-blessing">Divine Blessing</a> from a ledge to the right</li>
                     <li data-id="playthrough_20_23">Go through the fog gate, light the bonfire and return to <a href="http://darksouls2.wikidot.com/majula">Majula</a>, level up, upgrade your weapons and armor, and buy any consumables you need</li>


### PR DESCRIPTION
Fixes to replace two placeholder X items & one area indented to showcase it is a footnote for an instruction.
