### PR TITLE
Base protocol for jquery inclusion on site protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <!--[if lt IE 9]>
         <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script src="//code.jquery.com/jquery-latest.js"></script>
     <script src="js/jstorage.js"></script>
     <script src="js/bootstrap.min.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
To avoid mixed content errors when called via https (like from github.io :)) use relative protocol instead of fixed http.
