### PR TITLE
Clarify Blacksmith's Hammer acquisition conditions (Majula location)

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
                             <li data-id="playthrough_3_24_15"><a href="http://darksouls2.wikidot.com/spear">Spear</a> @ 1,400 souls</li>
                         </ul>
                     </li>
-                    <li data-id="playthrough_3_25">If you spend 8,000 souls with him he will give you the <a href="http://darksouls2.wikidot.com/blacksmith-s-hammer">Blacksmith's Hammer</a></li>
+                    <li data-id="playthrough_3_25">If you spend 8,000 souls on reinforcements with him he will give you the <a href="http://darksouls2.wikidot.com/blacksmith-s-hammer">Blacksmith's Hammer</a></li>
                     <li data-id="playthrough_3_26">Optionally, kill him to get the <a href="http://darksouls2.wikidot.com/blacksmith-s-hammer">Blacksmith's Hammer</a></li>
                     <li data-id="playthrough_3_27">Get the <a href="http://darksouls2.wikidot.com/short-bow">Short Bow</a> from the chest behind him</li>
                     <li data-id="playthrough_3_28">Travel back to the <a href="http://darksouls2.wikidot.com/forest-of-fallen-giants">Forest of Fallen Giants / Cardinal Tower</a> bonfire, go down the ladder, across the bridge and get the <a href="http://darksouls2.wikidot.com/soul-of-a-lost-undead">Soul Of A Lost Undead</a></li>


### PR DESCRIPTION
Updated text to clarify the conditions for receiving the Blacksmith's Hammer.